### PR TITLE
Fixes for issue #1.

### DIFF
--- a/tao-schedule-update.php
+++ b/tao-schedule-update.php
@@ -420,8 +420,6 @@ class TAO_ScheduleUpdate {
 		/**
 		 * Fires when a post has been duplicated.
 		 *
-		 * @since 2.3.0
-		 *
 		 * @param int  $new_post_id ID of the newly created post.
 		 */
 		do_action( 'TAO_ScheduleUpdate\\create_publishing_post', $new_post_id );

--- a/tao-schedule-update.php
+++ b/tao-schedule-update.php
@@ -366,6 +366,8 @@ class TAO_ScheduleUpdate {
 	 * @return void
 	 */
 	public static function prevent_status_change ( $new_status, $old_status, $post ) {
+		if ($new_status === $old_status && $new_status == self::$TAO_PUBLISH_STATUS) return;
+
 		if ( $old_status == self::$TAO_PUBLISH_STATUS && 'trash' != $new_status ) {
 			remove_action( 'save_post', create_function( '$post_id, $post', 'return TAO_ScheduleUpdate::save_meta( $post_id, $post );' ), 10 );
 
@@ -414,6 +416,15 @@ class TAO_ScheduleUpdate {
 
 		//and finally referencing the original post
 		add_post_meta( $new_post_id, self::$TAO_PUBLISH_STATUS . '_original', $post->ID );
+
+		/**
+		 * Fires when a post has been duplicated.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @param int  $new_post_id ID of the newly created post.
+		 */
+		do_action( 'TAO_ScheduleUpdate\\create_publishing_post', $new_post_id );
 
 		return $new_post_id;
 	}


### PR DESCRIPTION
- Add check at the beginning of 'prevent_status_change' method. This will avoid unnecessary post updates when the post status has not changed.
- Add action 'TAO_ScheduleUpdate\create_publishing_post' which will notify the application when a Scheduled Update post has been created.
