### PR TITLE
local time sync with config time on wp

### DIFF
--- a/js/publish-datepicker.js
+++ b/js/publish-datepicker.js
@@ -26,12 +26,12 @@ TAO_ScheduleUpdate.checkTime = function() {
 	var st = $('#' + TAO_ScheduleUpdate.datepicker.elementid).val();
 	var time = $('#tao_sc_publish_pubdate_time').find(':selected').val() + ':' + $('select[name=tao_sc_publish_pubdate_time_mins]').find(':selected').val();
 	st += ' ' + time;
+    var currentGmt = $("#tao_used_gmt").val();
 	var pattern = /(\d{2})\.(\d{2})\.(\d{4}) (\d{2})\:(\d{2})/;
-	var dt = new Date(st.replace(pattern,'$3-$2-$1T$4:$5:00'));
 
-	dt.setTime(dt.getTime() + dt.getTimezoneOffset()*60000);
-
-	if (dt < now) {
+    var datestring = st.replace(pattern,'$3-$2-$1 $4:$5:00');
+    var dt = new Date(datestring + ' ' + currentGmt);
+    if (now.getTime() > dt.getTime()) {
 		$('#pastmsg').show();
 	} else {
 		$('#pastmsg').hide();

--- a/tao-schedule-update.php
+++ b/tao-schedule-update.php
@@ -322,6 +322,9 @@ class TAO_ScheduleUpdate {
 		if ( !$stamp && TAO_ScheduleUpdate_Options::get( 'tsu_nodate' ) == 'nothing' ) {
 			$date = '';
 		}
+        $decTime = floatval(get_option('gmt_offset'));
+        $GMThour = floor($decTime);
+        $GMTmin = round(60*($decTime-$GMThour));
 ?>
 			<p>
 				<strong><?php _e( 'Releasedate', self::$TAO_PUBLISH_TEXTDOMAIN ); ?></strong>
@@ -342,6 +345,7 @@ class TAO_ScheduleUpdate {
 				<option value="<?php echo sprintf( '%02d', $i ); ?>" <?php echo $i == ceil( $dateo->format( 'i' ) / 10 ) * 10 ? 'selected' : ''; ?>><?php echo sprintf( '%02d', $i ); ?></option>
 				<?php endfor; ?>
 			</select>
+            <input type="hidden" name="tao_added_minuts" id="tao_used_gmt" value="GMT<?php echo $GMThour > 0 ? '+' : ''; echo sprintf( '%02d', $GMThour ).':'.sprintf( '%02d', $GMTmin) ?>">
 			<p>
 				<?php echo sprintf( __( 'Please enter <i>Time</i> as %s', self::$TAO_PUBLISH_TEXTDOMAIN ), self::get_timezone_string() ); ?>
 			</p>


### PR DESCRIPTION
Hi,

When checking if a scheduled update is not scheduled for the past, checking the client time vs scheduled time that must be given using the timezone defined on Wordpress.