### PR TITLE
Add Support for Public Post Preview

### DIFF
--- a/tao-schedule-update.php
+++ b/tao-schedule-update.php
@@ -310,7 +310,7 @@ class TAO_ScheduleUpdate {
 		}
 
 		// hides everything except the 'publish' button in the 'publish'-metabox
-		echo '<style> #duplicate-action, #delete-action, #minor-publishing-actions, #misc-publishing-actions, #preview-action {display:none;} </style>'; // WPCS: XSS okay.
+		echo '<style> #duplicate-action, #delete-action, #minor-publishing-actions, #misc-publishing-actions > div, #preview-action {display:none;} #misc-publishing-actions > div.public-post-preview { display:block!important; } </style>'; // WPCS: XSS okay.
 
 		wp_enqueue_script( 'jquery-ui-datepicker' );
 		$url = '//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/themes/blitzer/jquery-ui.min.css';


### PR DESCRIPTION
Currently, the CSS blocks pretty much all items in the publish box (not being done for Gutenberg & some other editors, for better or worse). However, this prevents the Public Post Preview (a rather popular plugin per https://wordpress.org/plugins/public-post-preview/) control from being shown.

This update keeps the existing behavior while allowing this one item to still be shown as it could be helpful/needed.

Meanwhile, I could potentially see some of the publish box elements simply not be hidden at all to avoid the need to selectively show certain things (per it never being in danger of being hidden in the first place.)

Btw, I'm currently using this on the site admin pages so that this behavior is done without editing the plugin files or anything (the part about seeing if it's a scheduled update is needed since it's not selectively being shown on the editor for scheduled updates like this CSS code otherwise is while it then effectively performs the same styling as this updated CSS):
```
<script>if(jQuery("#meta_tao_sc_publish").length>0){jQuery("#misc-publishing-actions > div").hide();jQuery("#misc-publishing-actions, #misc-publishing-actions > div.public-post-preview").show();}</script>
```

Btw, I've also posted this on the WP.org plugin support forum at: https://wordpress.org/support/topic/proposed-update-add-support-for-public-post-preview/